### PR TITLE
fix(types): Adding missing 'references' property

### DIFF
--- a/src/types/tsconfig.ts
+++ b/src/types/tsconfig.ts
@@ -22,4 +22,5 @@ export interface TSConfig {
   files?: string[];
   include?: string[];
   typeAcquisition?: TypeAcquisition;
+  references?: { path: string }[];
 }


### PR DESCRIPTION
The [references](https://www.typescriptlang.org/tsconfig/#references) property is missing on the `TSConfig` interface.